### PR TITLE
Resize downSamples_ before initialization

### DIFF
--- a/src/HTJ2KEncoder.hpp
+++ b/src/HTJ2KEncoder.hpp
@@ -85,6 +85,7 @@ public:
   std::vector<uint8_t> &getDecodedBytes(const FrameInfo &frameInfo)
   {
     frameInfo_ = frameInfo;
+    downSamples_.resize(frameInfo_.componentCount);
     for (int c = 0; c < frameInfo_.componentCount; ++c)
     {
       downSamples_[c].x = 1;
@@ -310,5 +311,5 @@ private:
   Point tileOffset_;
   Size blockDimensions_;
   std::vector<Size> precincts_;
-  bool isUsingColorTransform_;
+  bool isUsingColorTransform_{false};
 };

--- a/test/cpp/main.cpp
+++ b/test/cpp/main.cpp
@@ -127,6 +127,6 @@ int main(int argc, char **argv)
     // decodeFile("test/fixtures/j2c/CT2.j2c");
     // decodeFile("test/fixtures/j2c/MG1.j2c");
 
-    // encodeFile("test/fixtures/raw/CT1.RAW", {.width = 512, .height = 512, .bitsPerSample = 16, .componentCount = 1, .isSigned = true}, "test/fixtures/j2c/CT1.j2c");
+    encodeFile("test/fixtures/raw/CT1.RAW", {.width = 512, .height = 512, .bitsPerSample = 16, .componentCount = 1, .isSigned = true}, "test/fixtures/j2c/CT1.j2c");
     return 0;
 }


### PR DESCRIPTION
Avoids segfault in the test.

Re-enable the encoding test and set a default value for the color transform so it will pass.